### PR TITLE
Feat/projectile weapon

### DIFF
--- a/Assets/Animation/Weapon/Bow.meta
+++ b/Assets/Animation/Weapon/Bow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 637705dc4cdaa478880c14b59331256a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Weapon/Bow/Attack.anim
+++ b/Assets/Animation/Weapon/Bow/Attack.anim
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Attack
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 21300000, guid: 44a4efe1740d4f6aa7252eebd25be890, type: 3}
+    - time: 1
+      value: {fileID: 21300000, guid: 8e9b717c0b6342debbd2277f47e20eb3, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 21300000, guid: 44a4efe1740d4f6aa7252eebd25be890, type: 3}
+    - {fileID: 21300000, guid: 8e9b717c0b6342debbd2277f47e20eb3, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.0833334
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animation/Weapon/Bow/Attack.anim.meta
+++ b/Assets/Animation/Weapon/Bow/Attack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cdae4384b4cae4d9a9615020838e781b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Weapon/Bow/Bow.controller
+++ b/Assets/Animation/Weapon/Bow/Bow.controller
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-5948681874806450357
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4311182837850088361}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Bow
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Attack
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 3518144589741114314}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1107 &3518144589741114314
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 4311182837850088361}
+    m_Position: {x: 830, y: -30, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8872826490017122304}
+    m_Position: {x: 560, y: 30, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions:
+  - {fileID: -5948681874806450357}
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 570, y: -100, z: 0}
+  m_EntryPosition: {x: 570, y: -20, z: 0}
+  m_ExitPosition: {x: 850, y: -110, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 8872826490017122304}
+--- !u!1102 &4311182837850088361
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Attack
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: cdae4384b4cae4d9a9615020838e781b, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &8872826490017122304
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Animation/Weapon/Bow/Bow.controller.meta
+++ b/Assets/Animation/Weapon/Bow/Bow.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 28f4be53276264682aec451c2d3a4777
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Weapon/Rifle.meta
+++ b/Assets/Animation/Weapon/Rifle.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c36d516c43b3419995dddb21cf0c5d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Weapon/Rifle/Attack.anim
+++ b/Assets/Animation/Weapon/Rifle/Attack.anim
@@ -1,0 +1,75 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Attack
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 21300000, guid: 406cd22d1ae74fc8b965253237d2275b, type: 3}
+    - time: 0.083333336
+      value: {fileID: 0}
+    attribute: m_Sprite
+    path: muzle
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 12
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 1452755125
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 21300000, guid: 406cd22d1ae74fc8b965253237d2275b, type: 3}
+    - {fileID: 0}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.16666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animation/Weapon/Rifle/Attack.anim.meta
+++ b/Assets/Animation/Weapon/Rifle/Attack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3291ed12e59f420aaa26e5676033973
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animation/Weapon/Rifle/Rifle.controller
+++ b/Assets/Animation/Weapon/Rifle/Rifle.controller
@@ -1,0 +1,133 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1101 &-5948681874806450357
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 4311182837850088361}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Rifle
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Attack
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 3518144589741114314}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1107 &3518144589741114314
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 4311182837850088361}
+    m_Position: {x: 830, y: -30, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8872826490017122304}
+    m_Position: {x: 560, y: 30, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions:
+  - {fileID: -5948681874806450357}
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 570, y: -100, z: 0}
+  m_EntryPosition: {x: 570, y: -20, z: 0}
+  m_ExitPosition: {x: 850, y: -110, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 8872826490017122304}
+--- !u!1102 &4311182837850088361
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Attack
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b3291ed12e59f420aaa26e5676033973, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &8872826490017122304
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: idle
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Animation/Weapon/Rifle/Rifle.controller.meta
+++ b/Assets/Animation/Weapon/Rifle/Rifle.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c1635670084a447e8f70d259945870d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Character/ArcherFrog.prefab
+++ b/Assets/Prefabs/Enemy/Character/ArcherFrog.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &264105597905583102
+--- !u!1 &2178633012169916736
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,38 +8,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3517962204864732197}
-  m_Layer: 8
-  m_Name: GroundCheckTop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3517962204864732197
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 264105597905583102}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.254, y: 0.23, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6428679312395715546}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2187064450729849477
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8811143781708207882}
+  - component: {fileID: 2271970457888026731}
   m_Layer: 8
   m_Name: GroundCheckFront
   m_TagString: Untagged
@@ -47,22 +16,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8811143781708207882
+--- !u!4 &2271970457888026731
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2187064450729849477}
+  m_GameObject: {fileID: 2178633012169916736}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.239, y: -0.222, z: 0}
+  m_LocalPosition: {x: 0.15, y: -0.15, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6428679312395715546}
+  m_Father: {fileID: 3725604400757442199}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5410065622438272760
+--- !u!1 &3770966055253752461
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -70,38 +39,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6178401273193131715}
-  m_Layer: 8
-  m_Name: GroundCheckCenter
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6178401273193131715
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5410065622438272760}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.22199999, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6428679312395715546}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5987775045333818747
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9123453551777593384}
+  - component: {fileID: 8361212657572629262}
   m_Layer: 8
   m_Name: GroundCheckStepUp
   m_TagString: Untagged
@@ -109,22 +47,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &9123453551777593384
+--- !u!4 &8361212657572629262
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5987775045333818747}
+  m_GameObject: {fileID: 3770966055253752461}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.373, y: 0.154, z: 0}
+  m_LocalPosition: {x: 0.215, y: 0.069, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6428679312395715546}
+  m_Father: {fileID: 3725604400757442199}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6364552244614852839
+--- !u!1 &6863808258197024613
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -132,30 +70,30 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 832108012977935120}
+  - component: {fileID: 2652886255404816403}
   m_Layer: 8
-  m_Name: GroundCheckBack
+  m_Name: GroundCheckTop
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &832108012977935120
+--- !u!4 &2652886255404816403
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6364552244614852839}
+  m_GameObject: {fileID: 6863808258197024613}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.23, y: -0.22199999, z: 0}
+  m_LocalPosition: {x: -0.155, y: 0.064, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6428679312395715546}
+  m_Father: {fileID: 3725604400757442199}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8437554141696259431
+--- !u!1 &7412631041521350378
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -163,46 +101,46 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1332481960248737082}
-  - component: {fileID: 4802846330986505012}
-  - component: {fileID: 7094934525566895059}
-  - component: {fileID: 6942169592057458539}
-  - component: {fileID: 206231485295626653}
-  - component: {fileID: 3086154318967958022}
-  - component: {fileID: 7446688044297608900}
+  - component: {fileID: 3886993343342114725}
+  - component: {fileID: 1395052655882912472}
+  - component: {fileID: 8353433035077783825}
+  - component: {fileID: 3799422853901950393}
+  - component: {fileID: 1152729703471813369}
+  - component: {fileID: 4013208373582707418}
+  - component: {fileID: 5225160546783576422}
   m_Layer: 8
-  m_Name: SpikeHead
+  m_Name: ArcherFrog
   m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1332481960248737082
+--- !u!4 &3886993343342114725
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.4, y: 1.4, z: 1}
+  m_LocalScale: {x: 1.7, y: 1.7, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5068591638448142530}
-  - {fileID: 5560478959416235338}
-  - {fileID: 6428679312395715546}
+  - {fileID: 3725604400757442199}
+  - {fileID: 4872011092734150317}
+  - {fileID: 738384373908902876}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &4802846330986505012
+--- !u!212 &1395052655882912472
 SpriteRenderer:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -244,7 +182,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: 21300000, guid: 1508ab85aab80754fb0213cd79267961, type: 3}
+  m_Sprite: {fileID: -6367560908665664636, guid: cd947491a13509945aa1b644f9db3ef2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -254,56 +192,56 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_SpriteSortPoint: 0
---- !u!114 &7094934525566895059
+--- !u!114 &8353433035077783825
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 75bde8f3560cfea40aad262d2a835090, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Health
-  _maxHealth: 300
+  _maxHealth: 100
   _currentHealth: 0
---- !u!114 &6942169592057458539
+--- !u!114 &3799422853901950393
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c904571f5d2a429f8c6cfd7448dd302, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyController
+  m_EditorClassIdentifier: Assembly-CSharp::CharacterAIController
   _context:
-    Speed: 0.4
+    Speed: 1
     JumpForwardSpeed: 1.2
     JumpForce: 5
-    AttackRange: 0.7
+    AttackRange: 3
     SearchRange: 2
     BaseTargetLockRange: 0
     TargetTag: Player
-  _weapon: {fileID: 4460130515798819813}
-  _environmentSensor: {fileID: 7767269331947246720}
+  _weapon: {fileID: 7555583099610597272}
+  _environmentSensor: {fileID: 4072566480822075483}
   _baseTarget: {fileID: 0}
   _behaviourTreeBuilder: {fileID: 11400000, guid: 1a6b5f308c34349cf84418cd8d2e99fd, type: 2}
   _isChasing: 1
---- !u!95 &206231485295626653
+--- !u!95 &1152729703471813369
 Animator:
   serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 94d585e6a974b426691556141875b3df, type: 2}
+  m_Controller: {fileID: 9100000, guid: fc9b2e6efff9d41c6b3d779a2d236a18, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -315,14 +253,14 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!50 &3086154318967958022
+--- !u!50 &4013208373582707418
 Rigidbody2D:
   serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -342,13 +280,13 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!61 &7446688044297608900
+--- !u!61 &5225160546783576422
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 7412631041521350378}
   m_Enabled: 1
   serializedVersion: 3
   m_Density: 1
@@ -376,19 +314,19 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: -0.034492183}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.54, y: 0.52}
+    oldSize: {x: 0.32, y: 0.32}
     newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.4, y: 0.43}
+  m_Size: {x: 0.2, y: 0.23101565}
   m_EdgeRadius: 0
---- !u!1 &8797489185098498003
+--- !u!1 &7792292137611447660
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -396,8 +334,39 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6428679312395715546}
-  - component: {fileID: 7767269331947246720}
+  - component: {fileID: 5912088391495011475}
+  m_Layer: 8
+  m_Name: GroundCheckCenter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5912088391495011475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7792292137611447660}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3725604400757442199}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8421028495682615143
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3725604400757442199}
+  - component: {fileID: 4072566480822075483}
   m_Layer: 8
   m_Name: GroundSensor
   m_TagString: Untagged
@@ -405,43 +374,43 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6428679312395715546
+--- !u!4 &3725604400757442199
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8797489185098498003}
+  m_GameObject: {fileID: 8421028495682615143}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8811143781708207882}
-  - {fileID: 6178401273193131715}
-  - {fileID: 832108012977935120}
-  - {fileID: 3517962204864732197}
-  - {fileID: 9123453551777593384}
-  m_Father: {fileID: 1332481960248737082}
+  - {fileID: 2271970457888026731}
+  - {fileID: 5912088391495011475}
+  - {fileID: 4194640115940342007}
+  - {fileID: 2652886255404816403}
+  - {fileID: 8361212657572629262}
+  m_Father: {fileID: 3886993343342114725}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7767269331947246720
+--- !u!114 &4072566480822075483
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8797489185098498003}
+  m_GameObject: {fileID: 8421028495682615143}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 41ac5f10895c54370a91a1d9472682d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnvironmentSensor
-  _groundCheckPointFront: {fileID: 8811143781708207882}
-  _groundCheckPointCenter: {fileID: 6178401273193131715}
-  _groundCheckPointTop: {fileID: 3517962204864732197}
-  _groundCheckPointBack: {fileID: 832108012977935120}
-  _groundCheckPointStepUp: {fileID: 9123453551777593384}
+  _groundCheckPointFront: {fileID: 2271970457888026731}
+  _groundCheckPointCenter: {fileID: 5912088391495011475}
+  _groundCheckPointTop: {fileID: 2652886255404816403}
+  _groundCheckPointBack: {fileID: 4194640115940342007}
+  _groundCheckPointStepUp: {fileID: 8361212657572629262}
   _groundLayer:
     serializedVersion: 2
     m_Bits: 64
@@ -449,29 +418,154 @@ MonoBehaviour:
   _raycastAcrossDistance: 1
   _raycastStepUpDistance: 0.8
   _raycastFallDistance: 4
---- !u!1001 &3263214839111522703
+--- !u!1 &8455434095023395433
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4194640115940342007}
+  m_Layer: 8
+  m_Name: GroundCheckBack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4194640115940342007
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8455434095023395433}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.15, y: -0.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3725604400757442199}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &2429506336322508592
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1332481960248737082}
+    m_TransformParent: {fileID: 3886993343342114725}
+    m_Modifications:
+    - target: {fileID: 3136778619705771243, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_Name
+      value: Bow
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.071
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.039
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3136778619705771245, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 28f4be53276264682aec451c2d3a4777, type: 2}
+    - target: {fileID: 5291032370037412008, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: _muzzle
+      value: 
+      objectReference: {fileID: 6589819940284881408}
+    - target: {fileID: 5291032370037412008, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: _projectilePrefab
+      value: 
+      objectReference: {fileID: 2444403896405954750, guid: de5898b2c435845e3bc26417ecdfddce, type: 3}
+    - target: {fileID: 5291032370037412008, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+      propertyPath: _weaponData.CoolTime
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+--- !u!4 &738384373908902876 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3136778619705771244, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+  m_PrefabInstance: {fileID: 2429506336322508592}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6589819940284881408 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8846452262393285936, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+  m_PrefabInstance: {fileID: 2429506336322508592}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7555583099610597272 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5291032370037412008, guid: 253a7b0cbfc02490ebcba97aa5a1295b, type: 3}
+  m_PrefabInstance: {fileID: 2429506336322508592}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fe87561f0d02468987c8d9a3f188a12, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ProjectileWeapon
+--- !u!1001 &2919135066097412064
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3886993343342114725}
     m_Modifications:
     - target: {fileID: 2747549760973772302, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: _health
       value: 
-      objectReference: {fileID: 7094934525566895059}
+      objectReference: {fileID: 8353433035077783825}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.141
+      value: 0.11612
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.141
+      value: 0.11612
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.116119996
+      value: 0.11612
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalPosition.x
@@ -479,7 +573,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.288
+      value: 0.141
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalPosition.z
@@ -491,15 +585,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -522,93 +616,8 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
---- !u!4 &5068591638448142530 stripped
+--- !u!4 &4872011092734150317 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
-  m_PrefabInstance: {fileID: 3263214839111522703}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &7395712880040186278
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1332481960248737082}
-    m_Modifications:
-    - target: {fileID: 1207306381360032749, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.079
-      objectReference: {fileID: 0}
-    - target: {fileID: 1949515359597075477, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771243, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_Name
-      value: Spike
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.392
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.247
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3456593500860536911, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f168ac94d40f2452eab210330c21c279, type: 3}
---- !u!114 &4460130515798819813 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6577305756939457091, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-  m_PrefabInstance: {fileID: 7395712880040186278}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d395051b1a94a45f6a25cd68771e140e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::Melee
---- !u!4 &5560478959416235338 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-  m_PrefabInstance: {fileID: 7395712880040186278}
+  m_PrefabInstance: {fileID: 2919135066097412064}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/Character/ArcherFrog.prefab.meta
+++ b/Assets/Prefabs/Enemy/Character/ArcherFrog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 09844f4039c61480f8a12f2002554621
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Character/Frog.prefab
+++ b/Assets/Prefabs/Enemy/Character/Frog.prefab
@@ -186,7 +186,7 @@ Transform:
   m_GameObject: {fileID: 8437554141696259431}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.53, y: 2.05, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1.7, y: 1.7, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/Assets/Prefabs/Enemy/Character/RifleFrog.prefab
+++ b/Assets/Prefabs/Enemy/Character/RifleFrog.prefab
@@ -167,7 +167,7 @@ MonoBehaviour:
   _weapon: {fileID: 4882076386516442205}
   _environmentSensor: {fileID: 4758019262235019534}
   _baseTarget: {fileID: 0}
-  _behaviourTreeBuilder: {fileID: 11400000, guid: be113ae93cdbd4f65829b06499b6e911, type: 2}
+  _behaviourTreeBuilder: {fileID: 11400000, guid: 1a6b5f308c34349cf84418cd8d2e99fd, type: 2}
   _isChasing: 1
 --- !u!95 &8415900586108805001
 Animator:

--- a/Assets/Prefabs/Enemy/Character/RifleFrog.prefab
+++ b/Assets/Prefabs/Enemy/Character/RifleFrog.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &264105597905583102
+--- !u!1 &341414833945678383
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,69 +8,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3517962204864732197}
-  m_Layer: 8
-  m_Name: GroundCheckTop
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3517962204864732197
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 264105597905583102}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.254, y: 0.23, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6428679312395715546}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2187064450729849477
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8811143781708207882}
-  m_Layer: 8
-  m_Name: GroundCheckFront
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8811143781708207882
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2187064450729849477}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.239, y: -0.222, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6428679312395715546}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5410065622438272760
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6178401273193131715}
+  - component: {fileID: 9031981671894129075}
   m_Layer: 8
   m_Name: GroundCheckCenter
   m_TagString: Untagged
@@ -78,22 +16,22 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6178401273193131715
+--- !u!4 &9031981671894129075
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5410065622438272760}
+  m_GameObject: {fileID: 341414833945678383}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.22199999, z: 0}
+  m_LocalPosition: {x: 0, y: -0.15, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 6428679312395715546}
+  m_Father: {fileID: 5714107543850850714}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &5987775045333818747
+--- !u!1 &646240635104298902
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -101,108 +39,46 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 9123453551777593384}
+  - component: {fileID: 3065660921938711759}
+  - component: {fileID: 1907034259434630497}
+  - component: {fileID: 7616068269907019304}
+  - component: {fileID: 5158456033600019224}
+  - component: {fileID: 8415900586108805001}
+  - component: {fileID: 1675922436582879416}
+  - component: {fileID: 3531691868662132404}
   m_Layer: 8
-  m_Name: GroundCheckStepUp
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &9123453551777593384
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5987775045333818747}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.373, y: 0.154, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6428679312395715546}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6364552244614852839
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 832108012977935120}
-  m_Layer: 8
-  m_Name: GroundCheckBack
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &832108012977935120
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6364552244614852839}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.23, y: -0.22199999, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6428679312395715546}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8437554141696259431
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1332481960248737082}
-  - component: {fileID: 4802846330986505012}
-  - component: {fileID: 7094934525566895059}
-  - component: {fileID: 6942169592057458539}
-  - component: {fileID: 206231485295626653}
-  - component: {fileID: 3086154318967958022}
-  - component: {fileID: 7446688044297608900}
-  m_Layer: 8
-  m_Name: SpikeHead
+  m_Name: RifleFrog
   m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1332481960248737082
+--- !u!4 &3065660921938711759
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.4, y: 1.4, z: 1}
+  m_LocalScale: {x: 1.7, y: 1.7, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5068591638448142530}
-  - {fileID: 5560478959416235338}
-  - {fileID: 6428679312395715546}
+  - {fileID: 5714107543850850714}
+  - {fileID: 5090980142258370862}
+  - {fileID: 7440101980054282157}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &4802846330986505012
+--- !u!212 &1907034259434630497
 SpriteRenderer:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -244,7 +120,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_MaskInteraction: 0
-  m_Sprite: {fileID: 21300000, guid: 1508ab85aab80754fb0213cd79267961, type: 3}
+  m_Sprite: {fileID: -6367560908665664636, guid: cd947491a13509945aa1b644f9db3ef2, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -254,56 +130,56 @@ SpriteRenderer:
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_SpriteSortPoint: 0
---- !u!114 &7094934525566895059
+--- !u!114 &7616068269907019304
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 75bde8f3560cfea40aad262d2a835090, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Health
-  _maxHealth: 300
+  _maxHealth: 100
   _currentHealth: 0
---- !u!114 &6942169592057458539
+--- !u!114 &5158456033600019224
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8c904571f5d2a429f8c6cfd7448dd302, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::EnemyController
+  m_EditorClassIdentifier: Assembly-CSharp::CharacterAIController
   _context:
-    Speed: 0.4
+    Speed: 1
     JumpForwardSpeed: 1.2
     JumpForce: 5
-    AttackRange: 0.7
-    SearchRange: 2
+    AttackRange: 5
+    SearchRange: 6
     BaseTargetLockRange: 0
     TargetTag: Player
-  _weapon: {fileID: 4460130515798819813}
-  _environmentSensor: {fileID: 7767269331947246720}
+  _weapon: {fileID: 4882076386516442205}
+  _environmentSensor: {fileID: 4758019262235019534}
   _baseTarget: {fileID: 0}
-  _behaviourTreeBuilder: {fileID: 11400000, guid: 1a6b5f308c34349cf84418cd8d2e99fd, type: 2}
+  _behaviourTreeBuilder: {fileID: 11400000, guid: be113ae93cdbd4f65829b06499b6e911, type: 2}
   _isChasing: 1
---- !u!95 &206231485295626653
+--- !u!95 &8415900586108805001
 Animator:
   serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 94d585e6a974b426691556141875b3df, type: 2}
+  m_Controller: {fileID: 9100000, guid: fc9b2e6efff9d41c6b3d779a2d236a18, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -315,14 +191,14 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!50 &3086154318967958022
+--- !u!50 &1675922436582879416
 Rigidbody2D:
   serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   m_BodyType: 0
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -342,13 +218,13 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
---- !u!61 &7446688044297608900
+--- !u!61 &3531691868662132404
 BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8437554141696259431}
+  m_GameObject: {fileID: 646240635104298902}
   m_Enabled: 1
   serializedVersion: 3
   m_Density: 1
@@ -376,19 +252,19 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0, y: -0.034492183}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.54, y: 0.52}
+    oldSize: {x: 0.32, y: 0.32}
     newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.4, y: 0.43}
+  m_Size: {x: 0.2, y: 0.23101565}
   m_EdgeRadius: 0
---- !u!1 &8797489185098498003
+--- !u!1 &4674344988256542430
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -396,8 +272,70 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6428679312395715546}
-  - component: {fileID: 7767269331947246720}
+  - component: {fileID: 8905391809196890986}
+  m_Layer: 8
+  m_Name: GroundCheckBack
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8905391809196890986
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4674344988256542430}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.15, y: -0.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5714107543850850714}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6399655124730122183
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1416075465824608759}
+  m_Layer: 8
+  m_Name: GroundCheckTop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1416075465824608759
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6399655124730122183}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.155, y: 0.064, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5714107543850850714}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8137068133163628047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5714107543850850714}
+  - component: {fileID: 4758019262235019534}
   m_Layer: 8
   m_Name: GroundSensor
   m_TagString: Untagged
@@ -405,43 +343,43 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6428679312395715546
+--- !u!4 &5714107543850850714
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8797489185098498003}
+  m_GameObject: {fileID: 8137068133163628047}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8811143781708207882}
-  - {fileID: 6178401273193131715}
-  - {fileID: 832108012977935120}
-  - {fileID: 3517962204864732197}
-  - {fileID: 9123453551777593384}
-  m_Father: {fileID: 1332481960248737082}
+  - {fileID: 3942970601290589567}
+  - {fileID: 9031981671894129075}
+  - {fileID: 8905391809196890986}
+  - {fileID: 1416075465824608759}
+  - {fileID: 7833553911216884543}
+  m_Father: {fileID: 3065660921938711759}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7767269331947246720
+--- !u!114 &4758019262235019534
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8797489185098498003}
+  m_GameObject: {fileID: 8137068133163628047}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 41ac5f10895c54370a91a1d9472682d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::EnvironmentSensor
-  _groundCheckPointFront: {fileID: 8811143781708207882}
-  _groundCheckPointCenter: {fileID: 6178401273193131715}
-  _groundCheckPointTop: {fileID: 3517962204864732197}
-  _groundCheckPointBack: {fileID: 832108012977935120}
-  _groundCheckPointStepUp: {fileID: 9123453551777593384}
+  _groundCheckPointFront: {fileID: 3942970601290589567}
+  _groundCheckPointCenter: {fileID: 9031981671894129075}
+  _groundCheckPointTop: {fileID: 1416075465824608759}
+  _groundCheckPointBack: {fileID: 8905391809196890986}
+  _groundCheckPointStepUp: {fileID: 7833553911216884543}
   _groundLayer:
     serializedVersion: 2
     m_Bits: 64
@@ -449,29 +387,91 @@ MonoBehaviour:
   _raycastAcrossDistance: 1
   _raycastStepUpDistance: 0.8
   _raycastFallDistance: 4
---- !u!1001 &3263214839111522703
+--- !u!1 &8229655030425014291
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7833553911216884543}
+  m_Layer: 8
+  m_Name: GroundCheckStepUp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7833553911216884543
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8229655030425014291}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.215, y: 0.069, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5714107543850850714}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8948412382922191728
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3942970601290589567}
+  m_Layer: 8
+  m_Name: GroundCheckFront
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3942970601290589567
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8948412382922191728}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.15, y: -0.15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5714107543850850714}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &3294610527146301539
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1332481960248737082}
+    m_TransformParent: {fileID: 3065660921938711759}
     m_Modifications:
     - target: {fileID: 2747549760973772302, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: _health
       value: 
-      objectReference: {fileID: 7094934525566895059}
+      objectReference: {fileID: 7616068269907019304}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalScale.x
-      value: 0.141
+      value: 0.11612
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalScale.y
-      value: 0.141
+      value: 0.11612
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalScale.z
-      value: 0.116119996
+      value: 0.11612
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalPosition.x
@@ -479,7 +479,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.288
+      value: 0.141
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalPosition.z
@@ -491,15 +491,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -522,93 +522,121 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
---- !u!4 &5068591638448142530 stripped
+--- !u!4 &5090980142258370862 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7718613025207476557, guid: 62e02196856fa4c06b0b6afd877ea733, type: 3}
-  m_PrefabInstance: {fileID: 3263214839111522703}
+  m_PrefabInstance: {fileID: 3294610527146301539}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &7395712880040186278
+--- !u!1001 &5532846817928715073
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1332481960248737082}
+    m_TransformParent: {fileID: 3065660921938711759}
     m_Modifications:
-    - target: {fileID: 1207306381360032749, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.079
+    - target: {fileID: 1083116013914425116, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: _burstShotInterval
+      value: 0.05
       objectReference: {fileID: 0}
-    - target: {fileID: 1949515359597075477, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_IsActive
-      value: 1
+    - target: {fileID: 1083116013914425116, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: _weaponData.CoolTime
+      value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771243, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771243, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_Name
-      value: Spike
+      value: Rifle
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.392
+      value: 0.047
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.247
+      value: -0.072
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
+    - target: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3456593500860536911, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-      propertyPath: m_IsActive
+    - target: {fileID: 3136778619705771246, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ab266b01abe94bf1969717b408794600, type: 3}
+    - target: {fileID: 5291032370037412008, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: _projectilePrefab
+      value: 
+      objectReference: {fileID: 2444403896405954750, guid: 2ed9a4abfbe294583b9df33b03d142f2, type: 3}
+    - target: {fileID: 5291032370037412008, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: _weaponData.CoolTime
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7340018678210127788, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7340018678210127788, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: m_WasSpriteAssigned
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8846452262393285936, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8846452262393285936, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8846452262393285936, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f168ac94d40f2452eab210330c21c279, type: 3}
---- !u!114 &4460130515798819813 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+--- !u!114 &4882076386516442205 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6577305756939457091, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-  m_PrefabInstance: {fileID: 7395712880040186278}
+  m_CorrespondingSourceObject: {fileID: 1083116013914425116, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+  m_PrefabInstance: {fileID: 5532846817928715073}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d395051b1a94a45f6a25cd68771e140e, type: 3}
+  m_Script: {fileID: 11500000, guid: 1e85c15daf00149ceb1ea04f633500e5, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::Melee
---- !u!4 &5560478959416235338 stripped
+  m_EditorClassIdentifier: Assembly-CSharp::BurstProjectileWeapon
+--- !u!4 &7440101980054282157 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3136778619705771244, guid: f168ac94d40f2452eab210330c21c279, type: 3}
-  m_PrefabInstance: {fileID: 7395712880040186278}
+  m_CorrespondingSourceObject: {fileID: 3136778619705771244, guid: c04956a353fee4aeba0abf2d85db937d, type: 3}
+  m_PrefabInstance: {fileID: 5532846817928715073}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/Character/RifleFrog.prefab.meta
+++ b/Assets/Prefabs/Enemy/Character/RifleFrog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f74163734383342228342b66c71ac98a
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Projectile.meta
+++ b/Assets/Prefabs/Enemy/Projectile.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70d64c7c1a21b4c8c8273bd74d79d272
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Projectile/Arrow.prefab
+++ b/Assets/Prefabs/Enemy/Projectile/Arrow.prefab
@@ -1,0 +1,199 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3903467889774677732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7020109513350344470}
+  - component: {fileID: 7669174101729926257}
+  - component: {fileID: 2444403896405954750}
+  - component: {fileID: 5189505191137795866}
+  - component: {fileID: 7228576395349140141}
+  - component: {fileID: 7620382765042887083}
+  m_Layer: 10
+  m_Name: Arrow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7020109513350344470
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.25, y: 0.35, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7669174101729926257
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 15
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 1db2d854f185433997395e2819c25ac9, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 8.16, y: 1.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &2444403896405954750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b309a067b8564e4486d8534a36e34fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Projectile
+  speed: 6
+  lifeTime: 3
+  damageAmount: 20
+  destroyOnHit: 1
+--- !u!114 &5189505191137795866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc06e9035cb044627ac2064544b0e269, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamageArea
+  _isAreaAttack: 0
+--- !u!50 &7228576395349140141
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 0
+--- !u!61 &7620382765042887083
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -0.11265087, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.64, y: 0.36}
+    newSize: {x: 8.16, y: 1.65}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1.2803078, y: 0.21}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Enemy/Projectile/Arrow.prefab.meta
+++ b/Assets/Prefabs/Enemy/Projectile/Arrow.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de5898b2c435845e3bc26417ecdfddce
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Projectile/RifleBullet.prefab
+++ b/Assets/Prefabs/Enemy/Projectile/RifleBullet.prefab
@@ -1,0 +1,199 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3903467889774677732
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7020109513350344470}
+  - component: {fileID: 7669174101729926257}
+  - component: {fileID: 2444403896405954750}
+  - component: {fileID: 5189505191137795866}
+  - component: {fileID: 7228576395349140141}
+  - component: {fileID: 7620382765042887083}
+  m_Layer: 10
+  m_Name: RifleBullet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7020109513350344470
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7669174101729926257
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 15
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 57e583ba1fb04e888579f9f77d920f17, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 8.16, y: 1.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &2444403896405954750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b309a067b8564e4486d8534a36e34fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Projectile
+  speed: 9
+  lifeTime: 3
+  damageAmount: 20
+  destroyOnHit: 1
+--- !u!114 &5189505191137795866
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc06e9035cb044627ac2064544b0e269, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamageArea
+  _isAreaAttack: 0
+--- !u!50 &7228576395349140141
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 0
+--- !u!61 &7620382765042887083
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3903467889774677732}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.25, y: 0.51}
+    newSize: {x: 8.16, y: 1.65}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 0.21}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Enemy/Projectile/RifleBullet.prefab.meta
+++ b/Assets/Prefabs/Enemy/Projectile/RifleBullet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2ed9a4abfbe294583b9df33b03d142f2
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Spawner/RandomSpawner.prefab
+++ b/Assets/Prefabs/Enemy/Spawner/RandomSpawner.prefab
@@ -139,6 +139,8 @@ MonoBehaviour:
   _enemyPre:
   - {fileID: 2447270333455950194, guid: ded1171ca88e54419be887a79100a009, type: 3}
   - {fileID: 6942169592057458539, guid: 60ec3d245fc7b47529faf9e76a50d792, type: 3}
+  - {fileID: 3799422853901950393, guid: 09844f4039c61480f8a12f2002554621, type: 3}
+  - {fileID: 5158456033600019224, guid: f74163734383342228342b66c71ac98a, type: 3}
   _maxCoolTime: 1
   _minCoolTime: 7
   _maxEnemyCount: 10

--- a/Assets/Prefabs/Enemy/Weapon/Bow.prefab
+++ b/Assets/Prefabs/Enemy/Weapon/Bow.prefab
@@ -1,0 +1,167 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3136778619705771243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3136778619705771244}
+  - component: {fileID: 3136778619705771246}
+  - component: {fileID: 5291032370037412008}
+  - component: {fileID: 3136778619705771245}
+  m_Layer: 10
+  m_Name: Bow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3136778619705771244
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 8846452262393285936}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3136778619705771246
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 11
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 8e9b717c0b6342debbd2277f47e20eb3, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.48, y: 4.32}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &5291032370037412008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fe87561f0d02468987c8d9a3f188a12, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::ProjectileWeapon
+  _weaponData:
+    WeaponName: Bow
+    DamageAmount: 5
+    CoolTime: 2
+  _projectilePrefab: {fileID: 2444403896405954750, guid: de5898b2c435845e3bc26417ecdfddce, type: 3}
+  _muzzle: {fileID: 8846452262393285936}
+--- !u!95 &3136778619705771245
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 28f4be53276264682aec451c2d3a4777, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &3686631877083754384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8846452262393285936}
+  m_Layer: 10
+  m_Name: muzle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8846452262393285936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3686631877083754384}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3136778619705771244}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Enemy/Weapon/Bow.prefab.meta
+++ b/Assets/Prefabs/Enemy/Weapon/Bow.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 253a7b0cbfc02490ebcba97aa5a1295b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Weapon/Rifle.prefab
+++ b/Assets/Prefabs/Enemy/Weapon/Rifle.prefab
@@ -1,0 +1,229 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3136778619705771243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3136778619705771244}
+  - component: {fileID: 3136778619705771246}
+  - component: {fileID: 1083116013914425116}
+  - component: {fileID: 3136778619705771245}
+  m_Layer: 10
+  m_Name: Rifle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3136778619705771244
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 0.15}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 8846452262393285936}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3136778619705771246
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 11
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: ab266b01abe94bf1969717b408794600, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.48, y: 4.32}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &1083116013914425116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e85c15daf00149ceb1ea04f633500e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BurstProjectileWeapon
+  _weaponData:
+    WeaponName: Rifle
+    DamageAmount: 5
+    CoolTime: 5
+  _projectilePrefab: {fileID: 2444403896405954750, guid: 2ed9a4abfbe294583b9df33b03d142f2, type: 3}
+  _muzzle: {fileID: 8846452262393285936}
+  _burstShotCount: 5
+  _burstShotInterval: 0.1
+--- !u!95 &3136778619705771245
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3136778619705771243}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 1c1635670084a447e8f70d259945870d, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &3686631877083754384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8846452262393285936}
+  - component: {fileID: 7340018678210127788}
+  m_Layer: 10
+  m_Name: muzle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8846452262393285936
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3686631877083754384}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.036, y: 0.158, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 3136778619705771244}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7340018678210127788
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3686631877083754384}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 16
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 21300000, guid: 406cd22d1ae74fc8b965253237d2275b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.55, y: 1.07}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/Enemy/Weapon/Rifle.prefab.meta
+++ b/Assets/Prefabs/Enemy/Weapon/Rifle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c04956a353fee4aeba0abf2d85db937d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/AI/NormalAIBulider.cs
+++ b/Assets/Script/AI/NormalAIBulider.cs
@@ -63,8 +63,8 @@ public class NormalAIBuilder : BehaviourTreeBuilder
             new IsTargetInAttackRange(),
             new StopVelocityX(),
             new BehaviourTrees.WaitForSeconds(0.3f),
-            new UseWeapon()
-        //new ChangeDirectionToTarget()
+            new UseWeapon(),
+            new ChangeDirectionToTarget()
         );
     }
 }

--- a/Assets/Script/StayCannon/Ballista/Bullet.cs
+++ b/Assets/Script/StayCannon/Ballista/Bullet.cs
@@ -15,22 +15,28 @@ public class Projectile : MonoBehaviour
     void Awake()
     {
         _hitbox = GetComponentsInChildren<Hitbox>(true);
+    }
+
+    public void Init(float damage)
+    {
+        damageAmount = damage;
+    }
+
+    void Start()
+    {
+        Destroy(gameObject, lifeTime);
         foreach (var hitbox in _hitbox)
         {
             hitbox.OnFirstHit += OnHit;
         }
     }
+
     void OnDestroy()
     {
         foreach (var hitbox in _hitbox)
         {
             hitbox.OnFirstHit -= OnHit;
         }
-    }
-
-    void Start()
-    {
-        Destroy(gameObject, lifeTime);
     }
 
     void Update()

--- a/Assets/Script/Weapon/BurstProjectileWeapon.cs
+++ b/Assets/Script/Weapon/BurstProjectileWeapon.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using UnityEngine;
+
+[RequireComponent(typeof(Animator))]
+public class BurstProjectileWeapon : ProjectileWeapon
+{
+    [SerializeField] private int _burstShotCount;
+    [SerializeField] private float _burstShotInterval;
+
+    protected override IEnumerator AttackCoroutine()
+    {
+        for (int i = 0; i < _burstShotCount; i++)
+        {
+            yield return base.AttackCoroutine();
+            yield return new WaitForSeconds(_burstShotInterval);
+        }
+    }
+}

--- a/Assets/Script/Weapon/BurstProjectileWeapon.cs.meta
+++ b/Assets/Script/Weapon/BurstProjectileWeapon.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e85c15daf00149ceb1ea04f633500e5

--- a/Assets/Script/Weapon/ContactWeapon.cs
+++ b/Assets/Script/Weapon/ContactWeapon.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using UnityEngine;
 
 [RequireComponent(typeof(Animator))]
-[RequireComponent(typeof(SpriteRenderer))]
 public class ContactWeapon : WeaponBase
 {
     private Animator _animator;

--- a/Assets/Script/Weapon/ProjectileWeapon.cs
+++ b/Assets/Script/Weapon/ProjectileWeapon.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using UnityEngine;
+
+[RequireComponent(typeof(Animator))]
+public class ProjectileWeapon : WeaponBase
+{
+    [SerializeField] private Projectile _projectilePrefab;
+    [SerializeField] private Transform _muzzle;
+    private Animator _animator;
+    readonly int _hashAttack = Animator.StringToHash("Attack");
+
+    protected override void Awake()
+    {
+        base.Awake();
+        _animator = GetComponent<Animator>();
+    }
+    protected override IEnumerator AttackCoroutine()
+    {
+        Projectile projectile = Instantiate(_projectilePrefab, _muzzle.position, _muzzle.rotation);
+        projectile.Init(_weaponData.DamageAmount);
+
+        _animator.SetTrigger(_hashAttack);
+        int layerIndex = 0;
+        float attackDuration = _animator.GetCurrentAnimatorStateInfo(layerIndex).length;
+        yield return new WaitForSeconds(attackDuration);
+    }
+}

--- a/Assets/Script/Weapon/ProjectileWeapon.cs.meta
+++ b/Assets/Script/Weapon/ProjectileWeapon.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fe87561f0d02468987c8d9a3f188a12

--- a/Assets/Script/Weapon/README.md
+++ b/Assets/Script/Weapon/README.md
@@ -9,7 +9,9 @@
 1. [WeaponData](#weapondata) — 武器パラメータ管理
 2. [WeaponBase](#weaponbase抽象基底クラス) — 攻撃フロー管理・状態制御
 3. [ContactWeapon](#contactweapon) — 接触判定型武器の実装
-4. [参考：クラス依存関係](#参考クラス依存関係)
+4. [ProjectileWeapon](#projectileweapon) — 投射物型武器の実装
+5. [BurstProjectileWeapon](#burstprojectileweapon) — 連射投射物型武器の実装
+6. [参考：クラス依存関係](#参考クラス依存関係)
 
 ---
 
@@ -325,6 +327,147 @@ Sword (GameObject)
 
 ---
 
+## ProjectileWeapon
+
+### 役割
+**投射物型の武器**。弾丸やミサイルなどのプロジェクタイルを発射します。  
+例：銃、弓、魔法などの遠距離武器
+
+### 設計方針
+- Projectile プレハブをインスタンス化して発射
+- Muzzle (銃口) から発射方向を決定
+- アニメーションで発射演出を実行
+
+### プロパティ
+
+| メンバー | 説明 | 型 | 役割 |
+|---------|------|-----|------|
+| `_projectilePrefab` | 発射する投射物のプレハブ | Projectile | インスタンス化して発射 |
+| `_muzzle` | 銃口の Transform（発射位置・方向） | Transform | 投射物の生成位置・回転 |
+| `_animator` | アニメーション制御 | Animator | 発射演出実行 |
+| `_hashAttack` | "Attack" パラメータのハッシュ | int | アニメーション制御 |
+
+### メソッド
+
+#### protected override void Awake()
+
+**役割** — コンポーネント初期化。
+
+```csharp
+protected override void Awake()
+{
+    base.Awake();  // WeaponBase の初期化（_renderer取得）
+    _animator = GetComponent<Animator>();
+}
+```
+
+#### protected override IEnumerator AttackCoroutine()
+
+**役割** — 投射物発射の演出。
+
+```csharp
+protected override IEnumerator AttackCoroutine()
+{
+    Projectile projectile = Instantiate(_projectilePrefab, _muzzle.position, _muzzle.rotation);
+    projectile.Init(_weaponData.DamageAmount);
+
+    _animator.SetTrigger(_hashAttack);
+    int layerIndex = 0;
+    float attackDuration = _animator.GetCurrentAnimatorStateInfo(layerIndex).length;
+    yield return new WaitForSeconds(attackDuration);
+}
+```
+
+**処理フロー**
+1. Projectile をインスタンス化（muzzle 位置・回転）
+2. Projectile に ダメージ量を初期化
+3. "Attack" アニメーションをトリガー
+4. アニメーション長だけ待機
+5. 完了したら WeaponBase が状態遷移
+
+### セットアップ例
+
+```
+Gun (GameObject)
+├── ProjectileWeapon (Component)
+│   ├── Projectile Prefab: [Bullet.prefab]
+│   └── Muzzle: [Muzzle Transform]
+├── Animator
+├── SpriteRenderer
+└── Muzzle (子オブジェクト)
+    └── Transform（発射位置・方向の基準点）
+```
+
+---
+
+## BurstProjectileWeapon
+
+### 役割
+**連射投射物型の武器**。ProjectileWeapon を継承し、複数回の連射を実現します。  
+例：マシンガン、連射弓、連続魔法など
+
+### 設計方針
+- ProjectileWeapon の AttackCoroutine を複数回ループ
+- 各射撃間に指定時間のインターバルを設定
+- 親クラスの状態管理を活用
+
+### プロパティ
+
+| メンバー | 説明 | 型 | 役割 |
+|---------|------|-----|------|
+| `_burstShotCount` | 連射する回数 | int | 発射回数を制御 |
+| `_burstShotInterval` | 各射撃間のインターバル（秒） | float | 射撃間の時間待機 |
+
+### メソッド
+
+#### protected override IEnumerator AttackCoroutine()
+
+**役割** — 連射の実行。
+
+```csharp
+protected override IEnumerator AttackCoroutine()
+{
+    for (int i = 0; i < _burstShotCount; i++)
+    {
+        yield return base.AttackCoroutine();
+        yield return new WaitForSeconds(_burstShotInterval);
+    }
+}
+```
+
+**処理フロー**
+1. `_burstShotCount` 回ループ
+2. 各ループで `base.AttackCoroutine()` 実行（親クラスの発射処理）
+3. インターバル待機
+4. 次の射撃へ
+5. すべて完了したら WeaponBase が状態遷移
+
+### 使用例
+
+```csharp
+// Inspector での設定
+_burstShotCount = 3        // 3回連射
+_burstShotInterval = 0.2f  // 各射撃間 0.2 秒
+```
+
+結果: 0秒目に1発 → 0.2秒後に2発 → 0.2秒後に3発
+
+### セットアップ例
+
+```
+MachineGun (GameObject)
+├── BurstProjectileWeapon (Component)
+│   ├── Burst Shot Count: 3
+│   ├── Burst Shot Interval: 0.2
+│   ├── Projectile Prefab: [Bullet.prefab]
+│   └── Muzzle: [Muzzle Transform]
+├── Animator
+├── SpriteRenderer
+└── Muzzle (子オブジェクト)
+```
+
+---
+
 ## 参考：クラス依存関係
 
 ```
@@ -335,11 +478,16 @@ WeaponData
 WeaponBase
     ↑
     │ 継承
+    ├─→ ContactWeapon
+    │       │
+    │       └─ Hitbox[] を管理
+    │           └─ Health イベント受信
     │
-ContactWeapon
-    │
-    └─ Hitbox[] を管理
-        └─ Health イベント受信
+    └─→ ProjectileWeapon
+            │
+            └─→ BurstProjectileWeapon
+                    │
+                    └─ Projectile[] を発射
 ```
 
 ---

--- a/Assets/Script/Weapon/WeaponBase.cs
+++ b/Assets/Script/Weapon/WeaponBase.cs
@@ -36,7 +36,7 @@ public abstract class WeaponBase : MonoBehaviour
     private IEnumerator AttackAndCooldown()
     {
         CurrentState = WeaponState.Attacking;
-        yield return StartCoroutine(AttackCoroutine());
+        yield return AttackCoroutine();
 
         CurrentState = WeaponState.CoolingDown;
         yield return new WaitForSeconds(_weaponData.CoolTime);

--- a/Assets/Script/Weapon/WeaponData.cs
+++ b/Assets/Script/Weapon/WeaponData.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine;
 
 [Serializable]
 public class WeaponData

--- a/doc/Weapon.md
+++ b/doc/Weapon.md
@@ -153,7 +153,7 @@ public class ContactWeapon : WeaponBase
 }
 ```
 
-#### 2. ProjectileWeapon（弾発射武器 TODO:これから作る予定）
+#### 2. ProjectileWeapon
 銃、弓など、プロジェクタイルを発射する武器。(**Hitbox を使用しない**,ダメージは弾側で処理)
 
 ```csharp


### PR DESCRIPTION
# ProjectileWeaponの追加

## 概要
・弾を発射するための武器クラスを追加しました。
・ドキュメントに新たなクラスの詳細を追加しました。
・新しい武器として、BowとRifleを追加しました。
・Bowを持った敵を追加しました。以降、RandomSpawnerからスポーンするようになります。
・Rifleを持った敵を追加しました。以降、RandomSpawnerからスポーンするようになります。

---

## クラス
### ProjectileWeapon
・投射物型の武器
・弓矢や弾丸などのプロジェクタイルを発射します。  
・弾のダメージ量はこのクラスから設定できます
・例：銃、弓、魔法などの遠距離武器


### BurstProjectileWeapon
・連射投射物型の武器。ProjectileWeapon を継承し、複数回の連射を実現します。  
・例：マシンガン、連射弓、連続魔法など

---

## 武器
・`Assets/Prefabs/Enemy/Weapon`にBowとRifleのプレハブがあります。

---

## 弾
・`Assets/Prefabs/Enemy/Projectile`にArrowとRifleBulletのプレハブがあります。

---

## 敵
・`Assets/Prefabs/Enemy/Character`にプレハブがあります。

---

## その他
・Bulletクラスの`damageAmount`をInit関数で設定できるようにしました。